### PR TITLE
Add 'ts' annotation to readme docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Pipeable functions are also exported for both instances (default `Effect`, `parA
 
 In addition to default implementations additional exposed functions are:
 
-```
+```ts
 /* utils */
 export function error(message: string) {
   return new Error(message);

--- a/packages/effect/README.md
+++ b/packages/effect/README.md
@@ -14,7 +14,8 @@ You can think of this type as a computation that requires an environment `R` to 
 An important point to note in the implementation is the `src/overload.ts` file where we extend and define the new abstract types required to specialize `fp-ts` behaviour to respect the variance of `R` & `E`.
 
 The key difference is expressed in:
-```
+
+```ts
 export interface Chain3E<F extends URIS3> extends Apply3<F> {
   readonly chain: <R, E, A, R2, E2, B>(
     fa: Kind3<F, R, E, A>,
@@ -66,7 +67,8 @@ The module exposes 2 instances of the typeclass `type EffectMonad<T extends URIS
 Pipeable functions are also exported for both instances (default `Effect`, `parAp`, `parApFirst`, `parApSecond` for parallel)
 
 In addition to default implementations additional exposed functions are:
-```
+
+```ts
 /* utils */
 export function error(message: string) {
   return new Error(message);

--- a/packages/rpc/README.md
+++ b/packages/rpc/README.md
@@ -4,7 +4,7 @@ The idea behind this package is to allow you to easily derive an RPC implementat
 
 In general we cannot allow any effect to be serialized, in particular an effect that supports RPC integration has to satisfy:
 
-```
+```ts
 export type CanRemote = {
   [k: string]: { [h: string]: (...args: any[]) => T.Effect<any, Error, any> };
 };
@@ -12,7 +12,7 @@ export type CanRemote = {
 
 An example effect that support RPC:
 
-```
+```ts
 interface ModuleA extends CanRemote {
   moduleA: {
     sayHi(a: Serializable, b: Serializable): T.Effect<YourEnv, Error, SerializableOutput>;
@@ -22,7 +22,7 @@ interface ModuleA extends CanRemote {
 
 An example effect that cannot support RPC:
 
-```
+```ts
 interface ModuleA {
   moduleA: {
     runStuff<A>(f: (a:A) => void): T.Effect<YourEnv, Error, SerializableOutput>;
@@ -32,7 +32,7 @@ interface ModuleA {
 
 Note: you can always extract the RPC part as a separate effect and have your full effect extending the base RPC one.
 
-```
+```ts
 interface ModuleARPC extends CanRemote {
   moduleA: {
     sayHi(a: Serializable, b: Serializable): T.Effect<YourEnv, Error, SerializableOutput>;
@@ -48,7 +48,7 @@ type ModuleA = ModuleARPC & ModuleANoRPC
 
 In order to implement a client suppose you have an effect on the server side:
 
-```
+```ts
 export interface ModuleA extends CanRemote {
   moduleA: {
     sayHiAndReturn(s: string): T.Effect<T.NoEnv, Error, string>;
@@ -77,7 +77,7 @@ export function sayHiAndReturn(s: string): Effect<ModuleA, Error, string> {
 
 You can implement a client in this way:
 
-```
+```ts
 export const clientModuleA = reinterpretRemotely(moduleA, "url");
 
 export const {


### PR DESCRIPTION
I'm really excited about this project. Hopefully I can make more substantial contributions in the future, but here's a tiny modification that adds syntax highlighting to the docs. No problem if this isn't a change you prefer.

### before
<img width="1072" alt="Screen Shot 2019-11-20 at 11 39 28 AM" src="https://user-images.githubusercontent.com/6667096/69263311-acc1dd00-0b8a-11ea-838b-946a3ae91dcd.png">


### after
<img width="1103" alt="Screen Shot 2019-11-20 at 11 39 39 AM" src="https://user-images.githubusercontent.com/6667096/69263323-b3e8eb00-0b8a-11ea-947f-de904c0a5201.png">
