### PR TITLE
Instructions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - optimizations
+      - instructions
 
 jobs:
   build:

--- a/packages/effect/src/driver.ts
+++ b/packages/effect/src/driver.ts
@@ -218,7 +218,7 @@ export class DriverImpl<E, A> implements Driver<E, A> {
                 return effect;
             }
           }
-          return new T.EffectIO(T.EffectTag.Pure, frame.apply(value));
+          return frame.apply(value);
         }
         default:
           return frame.apply(value);

--- a/packages/effect/src/driver.ts
+++ b/packages/effect/src/driver.ts
@@ -302,9 +302,6 @@ export class DriverImpl<E, A> implements Driver<E, A> {
         }
         current = this.handle(go.f0);
         break;
-      case T.EffectTag.Suspended:
-        current = go.f0();
-        break;
       default:
         current = go;
     }
@@ -364,7 +361,7 @@ export class DriverImpl<E, A> implements Driver<E, A> {
             }
             break;
           case T.EffectTag.Suspended:
-            current = current.f0();
+            current = this.short(current.f0());
             break;
           case T.EffectTag.Async:
             this.contextSwitch(current.f0);

--- a/packages/effect/src/driver.ts
+++ b/packages/effect/src/driver.ts
@@ -201,23 +201,23 @@ export class DriverImpl<E, A> implements Driver<E, A> {
               case T.EffectTag.Pure:
                 this.complete(done(effect.f0) as Done<A>);
                 return;
+              /* istanbul ignore next */
               case T.EffectTag.Completed:
-                /* istanbul ignore next */
                 this.complete(effect.f0 as Exit<E, A>);
                 return;
+              /* istanbul ignore next */
               case T.EffectTag.Raised:
-                /* istanbul ignore next */
                 this.complete(effect.f0 as Cause<E>);
                 return;
+              /* istanbul ignore next */
               case T.EffectTag.Async:
-                /* istanbul ignore next */
                 this.contextSwitch(effect.f0);
                 return;
+              /* istanbul ignore next */
               case T.EffectTag.Suspended:
-                /* istanbul ignore next */
                 return effect.f0();
+              /* istanbul ignore next */
               case T.EffectTag.Map:
-                /* istanbul ignore next */
                 this.frameStack.push(new MapFrame(effect));
                 return effect.f0;
               /* istanbul ignore next */

--- a/packages/effect/src/driver.ts
+++ b/packages/effect/src/driver.ts
@@ -219,6 +219,18 @@ export class DriverImpl<E, A> implements Driver<E, A> {
                 return;
               case T.EffectTag.Suspended:
                 return effect.f0();
+              case T.EffectTag.Chain:
+                this.frameStack.push(makeFrame(effect.f1));
+
+                switch (effect.f0._tag) {
+                  case T.EffectTag.Pure:
+                    return this.next(effect.f0.f0);
+                  default:
+                    return effect.f0;
+                }
+              case T.EffectTag.Collapse:
+                this.frameStack.push(new FoldFrame(effect));
+                return effect.f0;
               default:
                 return effect;
             }

--- a/packages/effect/src/driver.ts
+++ b/packages/effect/src/driver.ts
@@ -42,12 +42,8 @@ class FoldFrame implements FoldFrame {
   constructor(private readonly c: T.Collapse) {}
   readonly _tag = "fold-frame" as const;
 
-  apply(u: unknown): T.Instructions {
-    return this.c.f2(u);
-  }
-  recover(cause: Cause<unknown>): T.Instructions {
-    return this.c.f1(cause);
-  }
+  apply = this.c.f2;
+  recover = this.c.f1;
 }
 
 interface MapFrame {
@@ -59,9 +55,7 @@ class MapFrame implements MapFrame {
   constructor(private readonly c: T.Map) {}
   readonly _tag = "map-frame" as const;
 
-  apply(u: unknown): unknown {
-    return this.c.f1(u);
-  }
+  apply = this.c.f1;
 }
 
 interface InterruptFrame {

--- a/packages/effect/src/driver.ts
+++ b/packages/effect/src/driver.ts
@@ -341,15 +341,83 @@ export class DriverImpl<E, A> implements Driver<E, A> {
             break;
           case T.EffectTag.Chain:
             this.frameStack.push(makeFrame(current.f1));
-            current = current.f0;
+
+            switch (current.f0._tag) {
+              case T.EffectTag.Pure:
+                current = this.next(current.f0.f0);
+                break;
+              case T.EffectTag.Completed:
+                if (current.f0.f0._tag === ExitTag.Done) {
+                  current = this.next(current.f0.f0.value);
+                } else {
+                  current = this.handle(current.f0.f0);
+                }
+                break;
+              case T.EffectTag.Raised:
+                if (current.f0.f0._tag === ExitTag.Interrupt) {
+                  this.interrupted = true;
+                }
+                current = this.handle(current.f0.f0);
+                break;
+              case T.EffectTag.Suspended:
+                current = current.f0.f0();
+                break;
+              default:
+                current = current.f0;
+            }
             break;
           case T.EffectTag.Map:
             this.frameStack.push(new MapFrame(current));
-            current = current.f0;
+
+            switch (current.f0._tag) {
+              case T.EffectTag.Pure:
+                current = this.next(current.f0.f0);
+                break;
+              case T.EffectTag.Completed:
+                if (current.f0.f0._tag === ExitTag.Done) {
+                  current = this.next(current.f0.f0.value);
+                } else {
+                  current = this.handle(current.f0.f0);
+                }
+                break;
+              case T.EffectTag.Raised:
+                if (current.f0.f0._tag === ExitTag.Interrupt) {
+                  this.interrupted = true;
+                }
+                current = this.handle(current.f0.f0);
+                break;
+              case T.EffectTag.Suspended:
+                current = current.f0.f0();
+                break;
+              default:
+                current = current.f0;
+            }
             break;
           case T.EffectTag.Collapse:
             this.frameStack.push(new FoldFrame(current));
-            current = current.f0;
+            switch (current.f0._tag) {
+              case T.EffectTag.Pure:
+                current = this.next(current.f0.f0);
+                break;
+              case T.EffectTag.Completed:
+                if (current.f0.f0._tag === ExitTag.Done) {
+                  current = this.next(current.f0.f0.value);
+                } else {
+                  current = this.handle(current.f0.f0);
+                }
+                break;
+              case T.EffectTag.Raised:
+                if (current.f0.f0._tag === ExitTag.Interrupt) {
+                  this.interrupted = true;
+                }
+                current = this.handle(current.f0.f0);
+                break;
+              case T.EffectTag.Suspended:
+                current = current.f0.f0();
+                break;
+              default:
+                current = current.f0;
+            }
             break;
           case T.EffectTag.InterruptibleRegion:
             if (this.interruptRegionStack === undefined) {

--- a/packages/effect/src/driver.ts
+++ b/packages/effect/src/driver.ts
@@ -214,6 +214,11 @@ export class DriverImpl<E, A> implements Driver<E, A> {
               case T.EffectTag.Raised:
                 this.complete(effect.f0 as Cause<E>);
                 return;
+              case T.EffectTag.Async:
+                this.contextSwitch(effect.f0);
+                return;
+              case T.EffectTag.Suspended:
+                return effect.f0();
               default:
                 return effect;
             }

--- a/packages/effect/src/driver.ts
+++ b/packages/effect/src/driver.ts
@@ -25,10 +25,12 @@ interface Frame {
   apply(u: unknown): T.Instructions;
 }
 
-const makeFrame = (f: FunctionN<[unknown], T.Instructions>): Frame => ({
-  _tag: "frame",
-  apply: f
-});
+class Frame implements Frame {
+  constructor(private readonly f: (u: unknown) => T.Instructions) {}
+  readonly _tag = "frame" as const;
+
+  apply = this.f;
+}
 
 interface FoldFrame {
   readonly _tag: "fold-frame";
@@ -223,7 +225,7 @@ export class DriverImpl<E, A> implements Driver<E, A> {
                 this.frameStack.push(new MapFrame(effect));
                 return effect.f0;
               case T.EffectTag.Chain:
-                this.frameStack.push(makeFrame(effect.f1));
+                this.frameStack.push(new Frame(effect.f1));
                 return effect.f0;
               case T.EffectTag.Collapse:
                 this.frameStack.push(new FoldFrame(effect));
@@ -340,7 +342,7 @@ export class DriverImpl<E, A> implements Driver<E, A> {
             current = undefined;
             break;
           case T.EffectTag.Chain:
-            this.frameStack.push(makeFrame(current.f1));
+            this.frameStack.push(new Frame(current.f1));
 
             switch (current.f0._tag) {
               case T.EffectTag.Pure:

--- a/packages/effect/src/driver.ts
+++ b/packages/effect/src/driver.ts
@@ -194,6 +194,10 @@ export class DriverImpl<E, A> implements Driver<E, A> {
     if (frame) {
       switch (frame._tag) {
         case "map-frame": {
+          if (this.frameStack.length === 0) {
+            this.complete(done(frame.apply(value)) as Done<A>);
+            return
+          }
           return new T.EffectIO(T.EffectTag.Pure, frame.apply(value));
         }
         default:

--- a/packages/effect/src/driver.ts
+++ b/packages/effect/src/driver.ts
@@ -219,6 +219,9 @@ export class DriverImpl<E, A> implements Driver<E, A> {
                 return;
               case T.EffectTag.Suspended:
                 return effect.f0();
+              case T.EffectTag.Map:
+                this.frameStack.push(new MapFrame(effect));
+                return effect.f0;
               case T.EffectTag.Chain:
                 this.frameStack.push(makeFrame(effect.f1));
 

--- a/packages/effect/src/driver.ts
+++ b/packages/effect/src/driver.ts
@@ -202,26 +202,34 @@ export class DriverImpl<E, A> implements Driver<E, A> {
                 this.complete(done(effect.f0) as Done<A>);
                 return;
               case T.EffectTag.Completed:
+                /* istanbul ignore next */
                 this.complete(effect.f0 as Exit<E, A>);
                 return;
               case T.EffectTag.Raised:
+                /* istanbul ignore next */
                 this.complete(effect.f0 as Cause<E>);
                 return;
               case T.EffectTag.Async:
+                /* istanbul ignore next */
                 this.contextSwitch(effect.f0);
                 return;
               case T.EffectTag.Suspended:
+                /* istanbul ignore next */
                 return effect.f0();
               case T.EffectTag.Map:
+                /* istanbul ignore next */
                 this.frameStack.push(new MapFrame(effect));
                 return effect.f0;
+              /* istanbul ignore next */
               case T.EffectTag.Chain:
                 this.frameStack.push(new Frame(effect.f1));
                 return effect.f0;
+              /* istanbul ignore next */
               case T.EffectTag.Collapse:
                 this.frameStack.push(new FoldFrame(effect));
                 return effect.f0;
               default:
+                /* istanbul ignore next */
                 return effect;
             }
           }

--- a/packages/effect/src/driver.ts
+++ b/packages/effect/src/driver.ts
@@ -224,13 +224,7 @@ export class DriverImpl<E, A> implements Driver<E, A> {
                 return effect.f0;
               case T.EffectTag.Chain:
                 this.frameStack.push(makeFrame(effect.f1));
-
-                switch (effect.f0._tag) {
-                  case T.EffectTag.Pure:
-                    return this.next(effect.f0.f0);
-                  default:
-                    return effect.f0;
-                }
+                return effect.f0;
               case T.EffectTag.Collapse:
                 this.frameStack.push(new FoldFrame(effect));
                 return effect.f0;

--- a/packages/effect/src/effect.ts
+++ b/packages/effect/src/effect.ts
@@ -44,7 +44,8 @@ export enum EffectTag {
   AccessInterruptible,
   AccessRuntime,
   AccessEnv,
-  ProvideEnv
+  ProvideEnv,
+  Map
 }
 
 export type NoEnv = unknown;
@@ -90,7 +91,8 @@ export type Instructions =
   | AccessInterruptible
   | AccessRuntime
   | AccessEnv
-  | ProvideEnv;
+  | ProvideEnv
+  | Map;
 
 export interface Pure<A = unknown> {
   readonly _tag: EffectTag.Pure;
@@ -121,6 +123,12 @@ export interface Chain<Z = unknown> {
   readonly _tag: EffectTag.Chain;
   readonly f0: Instructions;
   readonly f1: FunctionN<[Z], Instructions>;
+}
+
+export interface Map<A = unknown, B = unknown> {
+  readonly _tag: EffectTag.Map;
+  readonly f0: Instructions;
+  readonly f1: FunctionN<[A], B>;
 }
 
 export interface Collapse<E1 = unknown, A1 = unknown> {
@@ -440,11 +448,7 @@ function map_<R, E, A, B>(
   base: Effect<R, E, A>,
   f: FunctionN<[A], B>
 ): Effect<R, E, B> {
-  return new EffectIO(
-    EffectTag.Chain,
-    base,
-    (x: any) => new EffectIO(EffectTag.Pure, f(x))
-  ).asEffect;
+  return new EffectIO(EffectTag.Map, base, f).asEffect;
 }
 
 /**


### PR DESCRIPTION
We can gain perf by lowering operations to specific frames, this is not a major driver restructure

```
$ /home/runner/work/matechs-effect/matechs-effect/node_modules/.bin/ts-node bench/index.ts
native x 30,178 ops/sec ±1.90% (77 runs sampled)
effect x 20,981 ops/sec ±1.56% (81 runs sampled)
wave x 16,110 ops/sec ±1.94% (77 runs sampled)
qio x 19,264 ops/sec ±2.75% (77 runs sampled)
Fastest is native
$ /home/runner/work/matechs-effect/matechs-effect/node_modules/.bin/ts-node bench/nestedMap.ts
effect x 6,391 ops/sec ±2.18% (79 runs sampled)
wave x 3,040 ops/sec ±1.82% (72 runs sampled)
qio x 6,405 ops/sec ±1.76% (75 runs sampled)
Fastest is qio,effect
$ /home/runner/work/matechs-effect/matechs-effect/node_modules/.bin/ts-node bench/nestedChain.ts
effect x 622 ops/sec ±1.45% (79 runs sampled)
wave x 405 ops/sec ±9.47% (68 runs sampled)
qio x 643 ops/sec ±1.47% (76 runs sampled)
Fastest is qio
```